### PR TITLE
Extend API to allow the use of alternative to TypeReference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.zero_x_baadf00d</groupId>
     <artifactId>play-redis-module</artifactId>
-    <version>17.06</version>
+    <version>17.08</version>
     <name>Play Redis module</name>
     <description>Redis module for Play Framework 2</description>
     <url>https://github.com/0xbaadf00d/play-redis-module</url>

--- a/src/main/java/com/zero_x_baadf00d/play/module/redis/PlayRedis.java
+++ b/src/main/java/com/zero_x_baadf00d/play/module/redis/PlayRedis.java
@@ -24,6 +24,7 @@
 package com.zero_x_baadf00d.play.module.redis;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
 import redis.clients.jedis.Jedis;
 
 import java.util.List;
@@ -34,7 +35,8 @@ import java.util.concurrent.Callable;
  * a Redis database.
  *
  * @author Thibault Meyer
- * @version 17.03.25
+ * @author Pierre Adam
+ * @version 17.08.20
  * @since 16.03.09
  */
 public interface PlayRedis {
@@ -72,6 +74,28 @@ public interface PlayRedis {
     <T> T get(final String key, final TypeReference<T> typeReference);
 
     /**
+     * Retrieves an object by key.
+     *
+     * @param key   Item key
+     * @param clazz The object class
+     * @param <T>   Generic type of something
+     * @return object or {@code null}
+     * @since 17.08.20
+     */
+    <T> T get(final String key, final Class<?> clazz);
+
+    /**
+     * Retrieves an object by key.
+     *
+     * @param key      Item key
+     * @param javaType The object java type
+     * @param <T>      Generic type of something
+     * @return object or {@code null}
+     * @since 17.08.20
+     */
+    <T> T get(final String key, final JavaType javaType);
+
+    /**
      * Sets a value without expiration.
      *
      * @param key           Item key
@@ -95,6 +119,48 @@ public interface PlayRedis {
     <T> void set(final String key, final TypeReference<T> typeReference, final Object value, final int expiration);
 
     /**
+     * Sets a value without expiration.
+     *
+     * @param key   Item key
+     * @param clazz The object class
+     * @param value The value to set
+     * @since 17.08.20
+     */
+    void set(final String key, final Class<?> clazz, final Object value);
+
+    /**
+     * Sets a value with expiration.
+     *
+     * @param key        Item key
+     * @param clazz      The object class
+     * @param value      The value to set
+     * @param expiration expiration in seconds
+     * @since 17.08.20
+     */
+    void set(final String key, final Class<?> clazz, final Object value, final int expiration);
+
+    /**
+     * Sets a value without expiration.
+     *
+     * @param key      Item key
+     * @param javaType The object java type
+     * @param value    The value to set
+     * @since 17.08.20
+     */
+    void set(final String key, final JavaType javaType, final Object value);
+
+    /**
+     * Sets a value with expiration.
+     *
+     * @param key        Item key
+     * @param javaType   The object java type
+     * @param value      The value to set
+     * @param expiration expiration in seconds
+     * @since 17.08.20
+     */
+    void set(final String key, final JavaType javaType, final Object value, final int expiration);
+
+    /**
      * Retrieve a value from the cache, or set it from a default
      * Callable function. The value has no expiration.
      *
@@ -111,15 +177,69 @@ public interface PlayRedis {
      * Retrieve a value from the cache, or set it from a default
      * Callable function.
      *
+     * @param <T>           Generic type of something implementing {@code java.io.Serializable}
      * @param key           Item key
      * @param typeReference The object type reference
      * @param block         block returning value to set if key does not exist
      * @param expiration    expiration period in seconds
-     * @param <T>           Generic type of something implementing {@code java.io.Serializable}
      * @return value
      * @since 16.03.31
      */
-    <T> T getOrElse(final String key, final TypeReference<T> typeReference, final Callable<T> block, final int expiration);
+    <T> Object getOrElse(final String key, final TypeReference<T> typeReference, final Callable<T> block, final int expiration);
+
+    /**
+     * Retrieve a value from the cache, or set it from a default
+     * Callable function. The value has no expiration.
+     *
+     * @param key   Item key
+     * @param clazz The object class
+     * @param block block returning value to set if key does not exist
+     * @param <T>   Generic type of something
+     * @return value
+     * @since 17.08.20
+     */
+    <T> T getOrElse(final String key, final Class<?> clazz, final Callable<T> block);
+
+    /**
+     * Retrieve a value from the cache, or set it from a default
+     * Callable function.
+     *
+     * @param <T>        Generic type of something implementing {@code java.io.Serializable}
+     * @param key        Item key
+     * @param clazz      The object class
+     * @param block      block returning value to set if key does not exist
+     * @param expiration expiration period in seconds
+     * @return value
+     * @since 17.08.20
+     */
+    <T> T getOrElse(final String key, final Class<?> clazz, final Callable<T> block, final int expiration);
+
+    /**
+     * Retrieve a value from the cache, or set it from a default
+     * Callable function. The value has no expiration.
+     *
+     * @param key      Item key
+     * @param javaType The object java type
+     * @param block    block returning value to set if key does not exist
+     * @param <T>      Generic type of something
+     * @return value
+     * @since 17.08.20
+     */
+    <T> T getOrElse(final String key, final JavaType javaType, final Callable<T> block);
+
+    /**
+     * Retrieve a value from the cache, or set it from a default
+     * Callable function.
+     *
+     * @param <T>        Generic type of something implementing {@code java.io.Serializable}
+     * @param key        Item key
+     * @param javaType   The object java type
+     * @param block      block returning value to set if key does not exist
+     * @param expiration expiration period in seconds
+     * @return value
+     * @since 17.08.20
+     */
+    <T> T getOrElse(final String key, final JavaType javaType, final Callable<T> block, final int expiration);
 
     /**
      * Removes a value from the cache.
@@ -170,6 +290,48 @@ public interface PlayRedis {
     <T> void addInList(final String key, final TypeReference<T> typeReference, final Object value, final int maxItem);
 
     /**
+     * Add a value in a list.
+     *
+     * @param key   The list key
+     * @param clazz The object class
+     * @param value The value to add in the list
+     * @since 17.08.20
+     */
+    void addInList(final String key, final Class<?> clazz, final Object value);
+
+    /**
+     * Add a value in a list.
+     *
+     * @param key     The list key
+     * @param clazz   The object class
+     * @param value   The value to add in the list
+     * @param maxItem The number of entries to keep in list
+     * @since 17.08.20
+     */
+    void addInList(final String key, final Class<?> clazz, final Object value, final int maxItem);
+
+    /**
+     * Add a value in a list.
+     *
+     * @param key      The list key
+     * @param javaType The object java type
+     * @param value    The value to add in the list
+     * @since 17.08.20
+     */
+    void addInList(final String key, final JavaType javaType, final Object value);
+
+    /**
+     * Add a value in a list.
+     *
+     * @param key      The list key
+     * @param javaType The object java type
+     * @param value    The value to add in the list
+     * @param maxItem  The number of entries to keep in list
+     * @since 17.08.20
+     */
+    void addInList(final String key, final JavaType javaType, final Object value, final int maxItem);
+
+    /**
      * Get values from a list.
      *
      * @param key           The list key
@@ -192,6 +354,54 @@ public interface PlayRedis {
      * @since 16.05.09
      */
     <T> List<T> getFromList(final String key, final TypeReference<T> typeReference, final int offset, final int count);
+
+    /**
+     * Get values from a list.
+     *
+     * @param key   The list key
+     * @param clazz The object class
+     * @param <T>   Generic type of something implementing {@code java.io.Serializable}
+     * @return The values list
+     * @since 17.08.20
+     */
+    <T> List<T> getFromList(final String key, final Class<?> clazz);
+
+    /**
+     * Get values from a list.
+     *
+     * @param key    The list key
+     * @param clazz  The object class
+     * @param offset From where
+     * @param count  The number of items to retrieve
+     * @param <T>    Generic type of something implementing {@code java.io.Serializable}
+     * @return The values list
+     * @since 17.08.20
+     */
+    <T> List<T> getFromList(final String key, final Class<?> clazz, final int offset, final int count);
+
+    /**
+     * Get values from a list.
+     *
+     * @param key      The list key
+     * @param javaType The object java type
+     * @param <T>      Generic type of something implementing {@code java.io.Serializable}
+     * @return The values list
+     * @since 17.08.20
+     */
+    <T> List<T> getFromList(final String key, final JavaType javaType);
+
+    /**
+     * Get values from a list.
+     *
+     * @param key      The list key
+     * @param javaType The object java type
+     * @param offset   From where
+     * @param count    The number of items to retrieve
+     * @param <T>      Generic type of something implementing {@code java.io.Serializable}
+     * @return The values list
+     * @since 17.08.20
+     */
+    <T> List<T> getFromList(final String key, final JavaType javaType, final int offset, final int count);
 
     /**
      * Try to acquire a lock. This method will return {@code false} if

--- a/src/test/java/RedisTest.java
+++ b/src/test/java/RedisTest.java
@@ -40,7 +40,8 @@ import static org.mockito.Mockito.mock;
  * RedisTest.
  *
  * @author Thibault Meyer
- * @version 17.05.26
+ * @author Pierre Adam
+ * @version 17.08.20
  * @since 16.11.13
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -97,11 +98,19 @@ public class RedisTest extends AbstractRedisTest {
         });
         Assert.assertEquals("Hello World!", helloWorld);
 
+        this.playRedis.set("junit.item", String.class, "Hello World! class");
+        final String helloWorld2 = this.playRedis.get("junit.item", String.class);
+        Assert.assertEquals("Hello World! class", helloWorld2);
+
         this.playRedis.set("junit.item", new TypeReference<Integer>() {
         }, 42);
         final Long number = this.playRedis.get("junit.item", new TypeReference<Long>() {
         });
         Assert.assertEquals((Long) 42L, number);
+
+        this.playRedis.set("junit.item", Long.class, 1337L);
+        final Long number2 = this.playRedis.get("junit.item", Long.class);
+        Assert.assertEquals((Long) 1337L, number2);
     }
 
     /**
@@ -125,10 +134,8 @@ public class RedisTest extends AbstractRedisTest {
         }, 1);
         this.playRedis.addInList("junit.item", new TypeReference<Integer>() {
         }, 4);
-        this.playRedis.addInList("junit.item", new TypeReference<Integer>() {
-        }, 3);
-        this.playRedis.addInList("junit.item", new TypeReference<Integer>() {
-        }, 2);
+        this.playRedis.addInList("junit.item", Integer.class, 3);
+        this.playRedis.addInList("junit.item", Integer.class, 2);
         List<Integer> numbers = this.playRedis.getFromList("junit.item", new TypeReference<Integer>() {
         });
         Assert.assertArrayEquals(numbers.toArray(), new Integer[]{2, 3, 4, 1});
@@ -137,10 +144,8 @@ public class RedisTest extends AbstractRedisTest {
         }, 1, 3);
         this.playRedis.addInList("junit.item2", new TypeReference<Integer>() {
         }, 4, 3);
-        this.playRedis.addInList("junit.item2", new TypeReference<Integer>() {
-        }, 3, 3);
-        this.playRedis.addInList("junit.item2", new TypeReference<Integer>() {
-        }, 2, 3);
+        this.playRedis.addInList("junit.item2", Integer.class, 3, 3);
+        this.playRedis.addInList("junit.item2", Integer.class, 2, 3);
         numbers = this.playRedis.getFromList("junit.item2", new TypeReference<Integer>() {
         });
         Assert.assertArrayEquals(numbers.toArray(), new Integer[]{2, 3, 4});


### PR DESCRIPTION
Methodes `get`, `set`, `getOrElse`, `addInList` and `getFromList` can now use Class<?> or JavaType as alternative to TypeReference.