### PR TITLE
Update module for play 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.zero_x_baadf00d</groupId>
     <artifactId>play-redis-module</artifactId>
-    <version>17.08</version>
+    <version>17.11</version>
     <name>Play Redis module</name>
     <description>Redis module for Play Framework 2</description>
     <url>https://github.com/0xbaadf00d/play-redis-module</url>
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>com.typesafe.play</groupId>
             <artifactId>play_2.12</artifactId>
-            <version>2.6.0</version>
+            <version>2.6.7</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -187,7 +187,7 @@
         <dependency>
             <groupId>com.typesafe.play</groupId>
             <artifactId>play-test_2.12</artifactId>
-            <version>2.6.0</version>
+            <version>2.6.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.zero_x_baadf00d</groupId>
     <artifactId>play-redis-module</artifactId>
-    <version>17.06</version>
+    <version>17.08</version>
     <name>Play Redis module</name>
     <description>Redis module for Play Framework 2</description>
     <url>https://github.com/0xbaadf00d/play-redis-module</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.zero_x_baadf00d</groupId>
     <artifactId>play-redis-module</artifactId>
-    <version>20.06</version>
+    <version>20.06u1</version>
     <name>Play Redis module</name>
     <description>Redis module for Play Framework 2</description>
     <url>https://github.com/thibaultmeyer/play-redis-module</url>

--- a/src/main/java/com/zero_x_baadf00d/play/module/redis/PlayRedis.java
+++ b/src/main/java/com/zero_x_baadf00d/play/module/redis/PlayRedis.java
@@ -91,7 +91,7 @@ public interface PlayRedis {
      * @return object or {@code null}
      * @since 17.08.20
      */
-    <T> T get(final String key, final Class<?> clazz);
+    <T> T get(final String key, final Class<T> clazz);
 
     /**
      * Retrieves an object by key.
@@ -113,7 +113,7 @@ public interface PlayRedis {
      * @param <T>           Generic type of something
      * @since 16.03.31
      */
-    <T> void set(final String key, final TypeReference<T> typeReference, final Object value);
+    <T> void set(final String key, final TypeReference<T> typeReference, final T value);
 
     /**
      * Sets a value with expiration.
@@ -125,7 +125,7 @@ public interface PlayRedis {
      * @param <T>           Generic type of something
      * @since 16.03.31
      */
-    <T> void set(final String key, final TypeReference<T> typeReference, final Object value, final int expiration);
+    <T> void set(final String key, final TypeReference<T> typeReference, final T value, final int expiration);
 
     /**
      * Sets a value without expiration.
@@ -135,7 +135,7 @@ public interface PlayRedis {
      * @param value The value to set
      * @since 17.08.20
      */
-    void set(final String key, final Class<?> clazz, final Object value);
+    <T> void set(final String key, final Class<T> clazz, final T value);
 
     /**
      * Sets a value with expiration.
@@ -146,7 +146,7 @@ public interface PlayRedis {
      * @param expiration expiration in seconds
      * @since 17.08.20
      */
-    void set(final String key, final Class<?> clazz, final Object value, final int expiration);
+    <T> void set(final String key, final Class<T> clazz, final T value, final int expiration);
 
     /**
      * Sets a value without expiration.
@@ -207,7 +207,7 @@ public interface PlayRedis {
      * @return value
      * @since 17.08.20
      */
-    <T> T getOrElse(final String key, final Class<?> clazz, final Callable<T> block);
+    <T> T getOrElse(final String key, final Class<T> clazz, final Callable<T> block);
 
     /**
      * Retrieve a value from the cache, or set it from a default
@@ -221,7 +221,7 @@ public interface PlayRedis {
      * @return value
      * @since 17.08.20
      */
-    <T> T getOrElse(final String key, final Class<?> clazz, final Callable<T> block, final int expiration);
+    <T> T getOrElse(final String key, final Class<T> clazz, final Callable<T> block, final int expiration);
 
     /**
      * Retrieve a value from the cache, or set it from a default
@@ -306,7 +306,7 @@ public interface PlayRedis {
      * @param value The value to add in the list
      * @since 17.08.20
      */
-    void addInList(final String key, final Class<?> clazz, final Object value);
+    <T> void addInList(final String key, final Class<T> clazz, final T value);
 
     /**
      * Add a value in a list.
@@ -317,7 +317,7 @@ public interface PlayRedis {
      * @param maxItem The number of entries to keep in list
      * @since 17.08.20
      */
-    void addInList(final String key, final Class<?> clazz, final Object value, final int maxItem);
+    <T> void addInList(final String key, final Class<T> clazz, final T value, final int maxItem);
 
     /**
      * Add a value in a list.
@@ -373,7 +373,7 @@ public interface PlayRedis {
      * @return The values list
      * @since 17.08.20
      */
-    <T> List<T> getFromList(final String key, final Class<?> clazz);
+    <T> List<T> getFromList(final String key, final Class<T> clazz);
 
     /**
      * Get values from a list.
@@ -386,7 +386,7 @@ public interface PlayRedis {
      * @return The values list
      * @since 17.08.20
      */
-    <T> List<T> getFromList(final String key, final Class<?> clazz, final int offset, final int count);
+    <T> List<T> getFromList(final String key, final Class<T> clazz, final int offset, final int count);
 
     /**
      * Get values from a list.

--- a/src/main/java/com/zero_x_baadf00d/play/module/redis/PlayRedis.java
+++ b/src/main/java/com/zero_x_baadf00d/play/module/redis/PlayRedis.java
@@ -36,7 +36,7 @@ import java.util.concurrent.Callable;
  *
  * @author Thibault Meyer
  * @author Pierre Adam
- * @version 17.08.20
+ * @version 17.11.17
  * @since 16.03.09
  */
 public interface PlayRedis {
@@ -185,7 +185,7 @@ public interface PlayRedis {
      * @return value
      * @since 16.03.31
      */
-    <T> Object getOrElse(final String key, final TypeReference<T> typeReference, final Callable<T> block, final int expiration);
+    <T> T getOrElse(final String key, final TypeReference<T> typeReference, final Callable<T> block, final int expiration);
 
     /**
      * Retrieve a value from the cache, or set it from a default

--- a/src/main/java/com/zero_x_baadf00d/play/module/redis/PlayRedis.java
+++ b/src/main/java/com/zero_x_baadf00d/play/module/redis/PlayRedis.java
@@ -24,6 +24,7 @@
 package com.zero_x_baadf00d.play.module.redis;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
 import redis.clients.jedis.Jedis;
 
 import java.util.List;
@@ -34,7 +35,8 @@ import java.util.concurrent.Callable;
  * a Redis database.
  *
  * @author Thibault Meyer
- * @version 17.03.25
+ * @author Pierre Adam
+ * @version 17.08.20
  * @since 16.03.09
  */
 public interface PlayRedis {
@@ -72,6 +74,28 @@ public interface PlayRedis {
     <T> T get(final String key, final TypeReference<T> typeReference);
 
     /**
+     * Retrieves an object by key.
+     *
+     * @param key   Item key
+     * @param clazz The object class
+     * @param <T>   Generic type of something
+     * @return object or {@code null}
+     * @since 17.08.20
+     */
+    <T> T get(final String key, final Class<?> clazz);
+
+    /**
+     * Retrieves an object by key.
+     *
+     * @param key      Item key
+     * @param javaType The object java type
+     * @param <T>      Generic type of something
+     * @return object or {@code null}
+     * @since 17.08.20
+     */
+    <T> T get(final String key, final JavaType javaType);
+
+    /**
      * Sets a value without expiration.
      *
      * @param key           Item key
@@ -95,6 +119,48 @@ public interface PlayRedis {
     <T> void set(final String key, final TypeReference<T> typeReference, final Object value, final int expiration);
 
     /**
+     * Sets a value without expiration.
+     *
+     * @param key   Item key
+     * @param clazz The object class
+     * @param value The value to set
+     * @since 17.08.20
+     */
+    void set(final String key, final Class<?> clazz, final Object value);
+
+    /**
+     * Sets a value with expiration.
+     *
+     * @param key        Item key
+     * @param clazz      The object class
+     * @param value      The value to set
+     * @param expiration expiration in seconds
+     * @since 17.08.20
+     */
+    void set(final String key, final Class<?> clazz, final Object value, final int expiration);
+
+    /**
+     * Sets a value without expiration.
+     *
+     * @param key      Item key
+     * @param javaType The object java type
+     * @param value    The value to set
+     * @since 17.08.20
+     */
+    void set(final String key, final JavaType javaType, final Object value);
+
+    /**
+     * Sets a value with expiration.
+     *
+     * @param key        Item key
+     * @param javaType   The object java type
+     * @param value      The value to set
+     * @param expiration expiration in seconds
+     * @since 17.08.20
+     */
+    void set(final String key, final JavaType javaType, final Object value, final int expiration);
+
+    /**
      * Retrieve a value from the cache, or set it from a default
      * Callable function. The value has no expiration.
      *
@@ -111,15 +177,69 @@ public interface PlayRedis {
      * Retrieve a value from the cache, or set it from a default
      * Callable function.
      *
+     * @param <T>           Generic type of something implementing {@code java.io.Serializable}
      * @param key           Item key
      * @param typeReference The object type reference
      * @param block         block returning value to set if key does not exist
      * @param expiration    expiration period in seconds
-     * @param <T>           Generic type of something implementing {@code java.io.Serializable}
      * @return value
      * @since 16.03.31
      */
-    <T> T getOrElse(final String key, final TypeReference<T> typeReference, final Callable<T> block, final int expiration);
+    <T> Object getOrElse(final String key, final TypeReference<T> typeReference, final Callable<T> block, final int expiration);
+
+    /**
+     * Retrieve a value from the cache, or set it from a default
+     * Callable function. The value has no expiration.
+     *
+     * @param key   Item key
+     * @param clazz The object class
+     * @param block block returning value to set if key does not exist
+     * @param <T>   Generic type of something
+     * @return value
+     * @since 17.08.20
+     */
+    <T> T getOrElse(final String key, final Class<?> clazz, final Callable<T> block);
+
+    /**
+     * Retrieve a value from the cache, or set it from a default
+     * Callable function.
+     *
+     * @param <T>        Generic type of something implementing {@code java.io.Serializable}
+     * @param key        Item key
+     * @param clazz      The object class
+     * @param block      block returning value to set if key does not exist
+     * @param expiration expiration period in seconds
+     * @return value
+     * @since 17.08.20
+     */
+    <T> T getOrElse(final String key, final Class<?> clazz, final Callable<T> block, final int expiration);
+
+    /**
+     * Retrieve a value from the cache, or set it from a default
+     * Callable function. The value has no expiration.
+     *
+     * @param key      Item key
+     * @param javaType The object java type
+     * @param block    block returning value to set if key does not exist
+     * @param <T>      Generic type of something
+     * @return value
+     * @since 17.08.20
+     */
+    <T> T getOrElse(final String key, final JavaType javaType, final Callable<T> block);
+
+    /**
+     * Retrieve a value from the cache, or set it from a default
+     * Callable function.
+     *
+     * @param <T>        Generic type of something implementing {@code java.io.Serializable}
+     * @param key        Item key
+     * @param javaType   The object java type
+     * @param block      block returning value to set if key does not exist
+     * @param expiration expiration period in seconds
+     * @return value
+     * @since 17.08.20
+     */
+    <T> T getOrElse(final String key, final JavaType javaType, final Callable<T> block, final int expiration);
 
     /**
      * Removes a value from the cache.
@@ -170,6 +290,48 @@ public interface PlayRedis {
     <T> void addInList(final String key, final TypeReference<T> typeReference, final Object value, final int maxItem);
 
     /**
+     * Add a value in a list.
+     *
+     * @param key   The list key
+     * @param clazz The object class
+     * @param value The value to add in the list
+     * @since 17.08.20
+     */
+    void addInList(final String key, final Class<?> clazz, final Object value);
+
+    /**
+     * Add a value in a list.
+     *
+     * @param key     The list key
+     * @param clazz   The object class
+     * @param value   The value to add in the list
+     * @param maxItem The number of entries to keep in list
+     * @since 17.08.20
+     */
+    void addInList(final String key, final Class<?> clazz, final Object value, final int maxItem);
+
+    /**
+     * Add a value in a list.
+     *
+     * @param key      The list key
+     * @param javaType The object java type
+     * @param value    The value to add in the list
+     * @since 17.08.20
+     */
+    void addInList(final String key, final JavaType javaType, final Object value);
+
+    /**
+     * Add a value in a list.
+     *
+     * @param key      The list key
+     * @param javaType The object java type
+     * @param value    The value to add in the list
+     * @param maxItem  The number of entries to keep in list
+     * @since 17.08.20
+     */
+    void addInList(final String key, final JavaType javaType, final Object value, final int maxItem);
+
+    /**
      * Get values from a list.
      *
      * @param key           The list key
@@ -192,6 +354,54 @@ public interface PlayRedis {
      * @since 16.05.09
      */
     <T> List<T> getFromList(final String key, final TypeReference<T> typeReference, final int offset, final int count);
+
+    /**
+     * Get values from a list.
+     *
+     * @param key   The list key
+     * @param clazz The object class
+     * @param <T>   Generic type of something implementing {@code java.io.Serializable}
+     * @return The values list
+     * @since 17.08.20
+     */
+    <T> List<T> getFromList(final String key, final Class<?> clazz);
+
+    /**
+     * Get values from a list.
+     *
+     * @param key    The list key
+     * @param clazz  The object class
+     * @param offset From where
+     * @param count  The number of items to retrieve
+     * @param <T>    Generic type of something implementing {@code java.io.Serializable}
+     * @return The values list
+     * @since 17.08.20
+     */
+    <T> List<T> getFromList(final String key, final Class<?> clazz, final int offset, final int count);
+
+    /**
+     * Get values from a list.
+     *
+     * @param key      The list key
+     * @param javaType The object java type
+     * @param <T>      Generic type of something implementing {@code java.io.Serializable}
+     * @return The values list
+     * @since 17.08.20
+     */
+    <T> List<T> getFromList(final String key, final JavaType javaType);
+
+    /**
+     * Get values from a list.
+     *
+     * @param key      The list key
+     * @param javaType The object java type
+     * @param offset   From where
+     * @param count    The number of items to retrieve
+     * @param <T>      Generic type of something implementing {@code java.io.Serializable}
+     * @return The values list
+     * @since 17.08.20
+     */
+    <T> List<T> getFromList(final String key, final JavaType javaType, final int offset, final int count);
 
     /**
      * Try to acquire a lock. This method will return {@code false} if

--- a/src/main/java/com/zero_x_baadf00d/play/module/redis/PlayRedisImpl.java
+++ b/src/main/java/com/zero_x_baadf00d/play/module/redis/PlayRedisImpl.java
@@ -394,7 +394,7 @@ public class PlayRedisImpl implements PlayRedis {
     }
 
     @Override
-    public <T> T get(final String key, final Class<?> clazz) {
+    public <T> T get(final String key, final Class<T> clazz) {
         return this.get(key, Json.mapper().readerFor(clazz));
     }
 
@@ -429,22 +429,22 @@ public class PlayRedisImpl implements PlayRedis {
     }
 
     @Override
-    public <T> void set(final String key, final TypeReference<T> typeReference, final Object value) {
+    public <T> void set(final String key, final TypeReference<T> typeReference, final T value) {
         this.set(key, typeReference, value, 0);
     }
 
     @Override
-    public <T> void set(final String key, final TypeReference<T> typeReference, final Object value, final int expiration) {
+    public <T> void set(final String key, final TypeReference<T> typeReference, final T value, final int expiration) {
         this.set(key, Json.mapper().writerFor(typeReference), value, expiration);
     }
 
     @Override
-    public void set(final String key, final Class<?> clazz, final Object value) {
+    public <T> void set(final String key, final Class<T> clazz, final T value) {
         this.set(key, clazz, value, 0);
     }
 
     @Override
-    public void set(final String key, final Class<?> clazz, final Object value, final int expiration) {
+    public <T> void set(final String key, final Class<T> clazz, final T value, final int expiration) {
         this.set(key, Json.mapper().writerFor(clazz), value, expiration);
     }
 
@@ -492,12 +492,12 @@ public class PlayRedisImpl implements PlayRedis {
     }
 
     @Override
-    public <T> T getOrElse(final String key, final Class<?> clazz, final Callable<T> block) {
+    public <T> T getOrElse(final String key, final Class<T> clazz, final Callable<T> block) {
         return this.getOrElse(key, clazz, block, 0);
     }
 
     @Override
-    public <T> T getOrElse(final String key, final Class<?> clazz, final Callable<T> block, final int expiration) {
+    public <T> T getOrElse(final String key, final Class<T> clazz, final Callable<T> block, final int expiration) {
         return this.getOrElse(key, Json.mapper().readerFor(clazz), Json.mapper().writerFor(clazz), block, expiration);
     }
 
@@ -575,12 +575,12 @@ public class PlayRedisImpl implements PlayRedis {
     }
 
     @Override
-    public void addInList(final String key, final Class<?> clazz, final Object value) {
+    public <T> void addInList(final String key, final Class<T> clazz, final T value) {
         this.addInList(key, Json.mapper().writerFor(clazz), value);
     }
 
     @Override
-    public void addInList(final String key, final Class<?> clazz, final Object value,
+    public <T> void addInList(final String key, final Class<T> clazz, final T value,
                           final int maxItem) {
         this.addInList(key, Json.mapper().writerFor(clazz), value, maxItem);
     }
@@ -648,12 +648,12 @@ public class PlayRedisImpl implements PlayRedis {
     }
 
     @Override
-    public <T> List<T> getFromList(final String key, final Class<?> clazz) {
+    public <T> List<T> getFromList(final String key, final Class<T> clazz) {
         return this.getFromList(key, clazz, 0, -1);
     }
 
     @Override
-    public <T> List<T> getFromList(final String key, final Class<?> clazz, final int offset, final int count) {
+    public <T> List<T> getFromList(final String key, final Class<T> clazz, final int offset, final int count) {
         return this.getFromList(key, Json.mapper().readerFor(clazz), offset, count);
     }
 

--- a/src/test/java/RedisTest.java
+++ b/src/test/java/RedisTest.java
@@ -40,7 +40,8 @@ import static org.mockito.Mockito.mock;
  * RedisTest.
  *
  * @author Thibault Meyer
- * @version 17.05.26
+ * @author Pierre Adam
+ * @version 17.08.20
  * @since 16.11.13
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -97,11 +98,19 @@ public class RedisTest extends AbstractRedisTest {
         });
         Assert.assertEquals("Hello World!", helloWorld);
 
+        this.playRedis.set("junit.item", String.class, "Hello World! class");
+        final String helloWorld2 = this.playRedis.get("junit.item", String.class);
+        Assert.assertEquals("Hello World! class", helloWorld2);
+
         this.playRedis.set("junit.item", new TypeReference<Integer>() {
         }, 42);
         final Long number = this.playRedis.get("junit.item", new TypeReference<Long>() {
         });
         Assert.assertEquals((Long) 42L, number);
+
+        this.playRedis.set("junit.item", Long.class, 1337L);
+        final Long number2 = this.playRedis.get("junit.item", Long.class);
+        Assert.assertEquals((Long) 1337L, number2);
     }
 
     /**
@@ -125,10 +134,8 @@ public class RedisTest extends AbstractRedisTest {
         }, 1);
         this.playRedis.addInList("junit.item", new TypeReference<Integer>() {
         }, 4);
-        this.playRedis.addInList("junit.item", new TypeReference<Integer>() {
-        }, 3);
-        this.playRedis.addInList("junit.item", new TypeReference<Integer>() {
-        }, 2);
+        this.playRedis.addInList("junit.item", Integer.class, 3);
+        this.playRedis.addInList("junit.item", Integer.class, 2);
         List<Integer> numbers = this.playRedis.getFromList("junit.item", new TypeReference<Integer>() {
         });
         Assert.assertArrayEquals(numbers.toArray(), new Integer[]{2, 3, 4, 1});
@@ -137,10 +144,8 @@ public class RedisTest extends AbstractRedisTest {
         }, 1, 3);
         this.playRedis.addInList("junit.item2", new TypeReference<Integer>() {
         }, 4, 3);
-        this.playRedis.addInList("junit.item2", new TypeReference<Integer>() {
-        }, 3, 3);
-        this.playRedis.addInList("junit.item2", new TypeReference<Integer>() {
-        }, 2, 3);
+        this.playRedis.addInList("junit.item2", Integer.class, 3, 3);
+        this.playRedis.addInList("junit.item2", Integer.class, 2, 3);
         numbers = this.playRedis.getFromList("junit.item2", new TypeReference<Integer>() {
         });
         Assert.assertArrayEquals(numbers.toArray(), new Integer[]{2, 3, 4});


### PR DESCRIPTION
Update of all the dependencies.

Maven plugins :
- maven-compiler-plugin `3.6.2` to `3.8.1`
- maven-javadoc-plugin `2.10.4` to `3.2.0`
- maven-source-plugin `3.0.1` to `3.2.1`
- jacoco-maven-plugin `0.7.9` to `0.8.5`

Dependencies :
- jedis `2.10.2` to `3.3.0`
- play_2.12 `2.6.20` to `2.8.2`
- junit `4.12` to `4.13`
- mockito-core `2.8.47` to `3.3.3`
- play-test_2.12 `2.6.20` to `2.8.2`

Fix test `redisConnTailTest_001_password_not_set` due to a change in the Jedis exceptions messages.
Fix test `redisTest_000_binding` to use the new play framework API.